### PR TITLE
Optimize logging levels for better performance

### DIFF
--- a/src/Game/Managers/GameManager.cpp
+++ b/src/Game/Managers/GameManager.cpp
@@ -457,7 +457,7 @@ namespace CppMMO
                             session->Send(std::span<const std::byte>(
                                 reinterpret_cast<const std::byte*>(builder.GetBufferPointer()), 
                                 builder.GetSize()));
-                            LOG_INFO("Sent S_WorldSnapshot to Player {} (Session {})", playerId, player.GetSessionId());
+                            LOG_DEBUG("Sent S_WorldSnapshot to Player {} (Session {})", playerId, player.GetSessionId());
                         }
                     }
                 }

--- a/src/Game/Services/AuthService.cpp
+++ b/src/Game/Services/AuthService.cpp
@@ -143,7 +143,7 @@ namespace CppMMO
                 response.success = false;
 
                 LOG_INFO("AuthService::HttpRequestSession: Received response from AuthServer. Status: {}", m_res.result_int());
-                LOG_INFO("Response Body: {}", m_res.body());
+                LOG_DEBUG("AuthService: Response received (body length: {} bytes)", m_res.body().length());
 
                 try
                 {

--- a/src/Network/Session.cpp
+++ b/src/Network/Session.cpp
@@ -80,7 +80,7 @@ namespace CppMMO
             m_writeQueue.enqueue(std::move(packetToSend));
 
             m_timer.cancel_one();
-            LOG_INFO("Session {}: Packet of total {} bytes (body {}) added to write queue.", m_sessionId, totalPacketLength, bodyLength);
+            LOG_DEBUG("Session {}: Packet of total {} bytes (body {}) added to write queue.", m_sessionId, totalPacketLength, bodyLength);
         }
 
         uint64_t Session::GetPlayerId() const

--- a/src/Utils/JobProcessor.cpp
+++ b/src/Utils/JobProcessor.cpp
@@ -122,7 +122,7 @@ namespace CppMMO
         void JobProcessor::ProcessJobPacket(const Job& job, const Protocol::UnifiedPacket* unifiedPacket)
         {
             Protocol::PacketId packetId = unifiedPacket->id();
-            LOG_INFO("JobProcessor: Received PacketId {} from Session {}", static_cast<int>(packetId), job.session->GetSessionId());
+            LOG_DEBUG("JobProcessor: Received PacketId {} from Session {}", static_cast<int>(packetId), job.session->GetSessionId());
             bool isNonGamePacket = false;
             switch (packetId)
             {
@@ -168,7 +168,7 @@ namespace CppMMO
                                 playerInputCommandData.sequenceNumber = c_player_input_packet->sequence_number();
                                 gameCommand.payload = playerInputCommandData;
                                 m_gameLogicQueue->PushGameCommand(std::move(gameCommand));
-                                LOG_INFO("In-game PacketId {} (C_PlayerInput) pushed to GameLogicQueue. InputFlags: {}, Seq: {}", static_cast<int>(packetId), c_player_input_packet->input_flags(), c_player_input_packet->sequence_number());
+                                LOG_DEBUG("In-game PacketId {} (C_PlayerInput) pushed to GameLogicQueue. InputFlags: {}, Seq: {}", static_cast<int>(packetId), c_player_input_packet->input_flags(), c_player_input_packet->sequence_number());
                             }
                             else
                             {

--- a/src/Utils/Logger.h
+++ b/src/Utils/Logger.h
@@ -41,10 +41,10 @@ namespace CppMMO{
 
                         // 2. Create sinks
                         auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-                        console_sink->set_level(spdlog::level::info);
+                        console_sink->set_level(spdlog::level::warn);
                         console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [thread %t] %v");
                     
-                        auto daily_file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>("../../../../logs/server.log", 0, 0, false, 30);
+                        auto daily_file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>("./logs/server.log", 0, 0, false, 30);
                         daily_file_sink->set_level(spdlog::level::debug);
                         daily_file_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] [thread %t] [%s:%#] %v");
                     


### PR DESCRIPTION
- Changed high-frequency logs to DEBUG level:
  * S_WorldSnapshot transmission logs (60 TPS)
  * JobProcessor packet reception logs
  * Session packet send logs
  * C_PlayerInput processing logs
- Updated AuthService response body logging for security
- Adjusted console log level to WARN (only warnings/errors shown)
- Fixed log file path from relative to "./logs/server.log"
- File logs still capture DEBUG level for development needs

This prevents console spam during normal operation while maintaining detailed logging capabilities for debugging.